### PR TITLE
fix: resolve link checker race condition with Vite assets

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -43,8 +43,7 @@ jobs:
       id: lychee
       uses: lycheeverse/lychee-action@v2
       with:
-        #args: --base _site/ --verbose --no-progress '_site/**/*.html'
-        args: --base-url "https://www.calconnect.org/" --no-progress '_site/**/*.html'
+        args: --base _site/ --no-progress '_site/**/*.html'
         fail: false
 
     - name: Create Issue From File


### PR DESCRIPTION
The link checker was using `--base-url https://www.calconnect.org/` which checks all links against the live site. Since the link checker and deployment run concurrently on push to main, the checker would see stale Vite asset hashes that hadn't been deployed yet, producing thousands of false-positive 404s.

Switch to `--base _site/` which resolves local paths from the built output and still checks external URLs against the internet.

Closes #95, Closes #94, Closes #92, Closes #91, Closes #90